### PR TITLE
add link in remove item flash, add show action, add show view with li…

### DIFF
--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -11,8 +11,8 @@ class CartsController < ApplicationController
     item = Item.find(params[:item_id])
     @cart.remove_item(item.id)
     #need to make item.title into a link
-    # flash[:success] = "Successfully removed #{view_context.link_to('item.title', item_path(item))} from your cart.".html_safe
-    flash[:success] = "Successfully removed #{item.title} from your cart.".html_safe
+    flash[:success] = "Successfully removed #{view_context.link_to(item.title, item_path(item))} from your cart."
+    # flash[:success] = "Successfully removed #{item.title} from your cart.".html_safe
     redirect_to cart_path
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,4 +3,8 @@ class ItemsController < ApplicationController
   def index
     @items = Item.all
   end
+
+  def show
+    @item = Item.find(params[:id])
+  end
 end

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,0 +1,5 @@
+<%= @item.title %>
+<%= number_to_currency(@item.dollars) %>
+<%= image_tag @item.image_url %>
+
+<%= button_to "Add to Cart", cart_path(item_id: @item.id) %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -37,7 +37,7 @@
 </div>
 
 <% flash.each do |type, msg| %>
-  <%= content_tag(:div, msg, class: "alert alert-#{type}") %>
+  <%= content_tag(:div, sanitize(msg), class: "alert alert-#{type}") %>
 <% end %>
 
 <%= yield %>

--- a/spec/features/user_can_remove_item_from_cart_spec.rb
+++ b/spec/features/user_can_remove_item_from_cart_spec.rb
@@ -25,14 +25,15 @@ RSpec.feature "visitor can remove item from cart" do
     # Then my current page should be "/cart"
     expect(current_path).to eq('/cart')
 
-    # And I should see a message styled in green
     # expect(flash[:success][:style]).to match(/color: green/)
-    # And the title "SOME_ITEM" should be a link to that item in case the user wants to add it back
+
     # expect(flash[:success]).to be_present
 
-
+    # And I should see a message styled in green
     # And the message should say "Successfully removed SOME_ITEM from your cart."
     expect(page).to have_content("Successfully removed Paperclip from your cart.")
+    # And the title "SOME_ITEM" should be a link to that item in case the user wants to add it back
+    expect(page).to have_link("#{item.title}", :href => "/items/#{item.id}")
     # And I should not see the item listed in cart
     within(".invoice_item") do
       expect(page).not_to have_content("Paperclip")


### PR DESCRIPTION
…nk to re-add item to cart.

This PR can be merged safely into development. It adds the link in the flash upon item removal from the cart and the link directs to the show page for the item with a link to add back to the cart in case the user wants to re-add it to their cart.